### PR TITLE
(fix): não deve mandar `deep_link` se não for uma uri válida.

### DIFF
--- a/src/services/pushNotification.js
+++ b/src/services/pushNotification.js
@@ -10,16 +10,18 @@ const beamsClient =
 
 export function sendNotification(login, { notificacao }) {
   const { assunto, conteudo, url_destino } = notificacao;
+
+  let notification = {
+    title: assunto,
+    body: conteudo,
+  };
+
+  if (url_destino) notification.deep_link = url_destino;
+
   beamsClient &&
     beamsClient
       .publishToUsers([login], {
-        web: {
-          notification: {
-            title: assunto,
-            body: conteudo,
-            deep_link: url_destino || "about:blank",
-          },
-        },
+        web: { notification },
       })
       .then((publishResponse) =>
         console.log("Just published:", publishResponse.publishId)


### PR DESCRIPTION
- versões anteriores do pusher-beams aceitavam `about:black` como uma
uri válida e obrigavam a mandar o campo `deep_link`
- agora o campo é opcional, e `about:black` não é mais válido.