### PR TITLE
(hotfix): parse da url do pusher pra usar https

### DIFF
--- a/src/services/pusher.js
+++ b/src/services/pusher.js
@@ -9,7 +9,10 @@ const config = {
 };
 
 if (process.env.PUSHER_HOST) {
-    config.host = process.env.PUSHER_HOST;
+    const endpoint = new URL(process.env.PUSHER_HOST);
+    config.host = endpoint.hostname;
+    config.scheme = endpoint.protocol.replace(':', '');
+    config.useTLS = endpoint.protocol === 'https:';
 }
 
 const pusher = new Pusher(config);


### PR DESCRIPTION
fiz isso pra conseguir especificar o https:// na url, e assim forçar o protocolo certo.