### PR TITLE
(hotfix): identificacao eh null

### DIFF
--- a/prisma/migrations/20251126185133_identificacao_eh_null/migration.sql
+++ b/prisma/migrations/20251126185133_identificacao_eh_null/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `notificacao` MODIFY `identificacao` VARCHAR(191) NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,7 +23,7 @@ model Notificacao {
   login         String
   pendente      Boolean
   sonoro        Boolean
-  identificacao String
+  identificacao String?
   urlDestino    String?  @map("url_destino") @db.Text
   criacao       DateTime @default(now())
   ativa         Boolean  @default(true)


### PR DESCRIPTION
Alguns sistemas não enviam a identificação da notificação e não vejo a necessidade do campo ser obrigatório.

<img width="1872" height="235" alt="image" src="https://github.com/user-attachments/assets/23a80f54-e3e0-4c6e-bea8-a6bb927995bb" />
